### PR TITLE
use 16-byte alignment for av_image_fill_arrays

### DIFF
--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -200,7 +200,7 @@ static bool avcodec_decoder_copy_frame(const avcodec_decoder d, opencv_mat mat, 
         // XXX make this below use mat's width/height
         uint8_t *data_ptrs[4];
         int linesizes[4];
-        av_image_fill_arrays(data_ptrs, linesizes, cvMat->data, AV_PIX_FMT_BGRA, frame->width, frame->height, 32);
+        av_image_fill_arrays(data_ptrs, linesizes, cvMat->data, AV_PIX_FMT_BGRA, frame->width, frame->height, 16);
         sws_scale(sws, frame->data, frame->linesize, 0, frame->height, data_ptrs, linesizes);
         sws_freeContext(sws);
         return true;

--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -200,6 +200,9 @@ static bool avcodec_decoder_copy_frame(const avcodec_decoder d, opencv_mat mat, 
         // XXX make this below use mat's width/height
         uint8_t *data_ptrs[4];
         int linesizes[4];
+        // XXX the magic value here (16) is the alignment of the array here. apparently 32 is needed for full SIMD
+        // utility but sometimes produces corrupted frames. 16 seems to alleviate that. Going down to 1 may fix
+        // some bugs, in theory
         av_image_fill_arrays(data_ptrs, linesizes, cvMat->data, AV_PIX_FMT_BGRA, frame->width, frame->height, 16);
         sws_scale(sws, frame->data, frame->linesize, 0, frame->height, data_ptrs, linesizes);
         sws_freeContext(sws);


### PR DESCRIPTION
32-byte may be able to use more simd primitives, but apparently it
causes distortion in some videos. we may even want to drop down to 1 if
we find other buggy videos