### PR TITLE
dont exceed 8 bits/channel

### DIFF
--- a/opencv.cpp
+++ b/opencv.cpp
@@ -40,6 +40,10 @@ int opencv_type_channels(int type) {
     return CV_MAT_CN(type);
 }
 
+int opencv_type_convert_depth(int t, int depth) {
+    return CV_MAKETYPE(depth, CV_MAT_CN(t));
+}
+
 opencv_decoder opencv_decoder_create(const opencv_mat buf) {
     auto mat = static_cast<const cv::Mat *>(buf);
     cv::ImageDecoder *d = new cv::ImageDecoder(*mat);

--- a/opencv.go
+++ b/opencv.go
@@ -126,6 +126,9 @@ func (f *Framebuffer) resizeMat(width, height int, pixelType PixelType) error {
 		C.opencv_mat_release(f.mat)
 		f.mat = nil
 	}
+	if pixelType.Depth() > 8 {
+		pixelType = PixelType(C.opencv_type_convert_depth(C.int(pixelType), C.CV_8U))
+	}
 	newMat := C.opencv_mat_create_from_data(C.int(width), C.int(height), C.int(pixelType), unsafe.Pointer(&f.buf[0]), C.size_t(len(f.buf)))
 	if newMat == nil {
 		return ErrBufTooSmall

--- a/opencv.hpp
+++ b/opencv.hpp
@@ -31,6 +31,7 @@ typedef void *opencv_encoder;
 
 int opencv_type_depth(int type);
 int opencv_type_channels(int type);
+int opencv_type_convert_depth(int type, int depth);
 
 opencv_decoder opencv_decoder_create(const opencv_mat buf);
 const char *opencv_decoder_get_description(const opencv_decoder d);


### PR DESCRIPTION
output format should never exceed 8 bits/channel. some output types
can't handle this, and our internal assumptions require this anyway.