### PR TITLE
use SWS_ACCURATE_RND for yuv -> bgra

### DIFF
--- a/avcodec.cpp
+++ b/avcodec.cpp
@@ -193,17 +193,16 @@ static int avcodec_decoder_copy_frame(const avcodec_decoder d, opencv_mat mat, A
     auto cvMat = static_cast<cv::Mat *>(mat);
 
     int res = avcodec_receive_frame(d->codec, frame);
-    if (res >= 0) {
+    if (res >= 0 && frame->width == cvMat->cols && frame->height == cvMat->rows) {
         struct SwsContext *sws = sws_getContext(frame->width, frame->height, (AVPixelFormat)(frame->format),
                                                 frame->width, frame->height, AV_PIX_FMT_BGRA,
-                                                SWS_BILINEAR, NULL, NULL, NULL);
-        // XXX make this below use mat's width/height
+                                                SWS_ACCURATE_RND, NULL, NULL, NULL);
         uint8_t *data_ptrs[4];
         int linesizes[4];
-        // XXX the magic value here (4) is the alignment of the array here. apparently 32 is needed for full SIMD
-        // utility but sometimes produces corrupted frames. 4 seems to alleviate that. Going down to 1 may fix
+        // XXX the magic value here (8) is the alignment of the array here. apparently 32 is needed for full SIMD
+        // utility but sometimes produces corrupted frames. 8 seems to alleviate that. Going down to 1 may fix
         // some bugs, in theory
-        av_image_fill_arrays(data_ptrs, linesizes, cvMat->data, AV_PIX_FMT_BGRA, frame->width, frame->height, 4);
+        av_image_fill_arrays(data_ptrs, linesizes, cvMat->data, AV_PIX_FMT_BGRA, frame->width, frame->height, 8);
         sws_scale(sws, frame->data, frame->linesize, 0, frame->height, data_ptrs, linesizes);
         sws_freeContext(sws);
     }


### PR DESCRIPTION
@jhgg pointed this out to me. With the latest changes, some videos have some glitches along the right-hand side. It seems turning this flag on finally fixes the issue, though I wish I could say why.

Here's a couple of mailing list issues on this topic, of conflicting viewpoints :/

https://ffmpeg.org/pipermail/libav-user/2012-July/002451.html
https://mailman.videolan.org/pipermail/vlc-devel/2012-January/084762.html