### PR TITLE
Add range check to NewDecoder

### DIFF
--- a/lilliput.go
+++ b/lilliput.go
@@ -62,7 +62,7 @@ func isGIF(maybeGIF []byte) bool {
 func NewDecoder(buf []byte) (Decoder, error) {
 	// Check buffer length before accessing it
 	if len(buf) == 0 {
-		return nil, ErrBufTooSmall
+		return nil, ErrInvalidImage
 	}
 
 	isBufGIF := isGIF(buf)

--- a/lilliput.go
+++ b/lilliput.go
@@ -59,6 +59,11 @@ func isGIF(maybeGIF []byte) bool {
 // image data provided in buf. If the first few bytes of buf do not
 // point to a valid magic string, an error will be returned.
 func NewDecoder(buf []byte) (Decoder, error) {
+	// Check buffer length before accessing it
+	if len(buf) == 0 {
+		return nil, errors.New("Image buffer is empty")
+	}
+
 	isBufGIF := isGIF(buf)
 	if isBufGIF {
 		return newGifDecoder(buf)

--- a/lilliput.go
+++ b/lilliput.go
@@ -10,9 +10,11 @@ import (
 )
 
 var (
-	ErrInvalidImage   = errors.New("unrecognized image format")
-	ErrDecodingFailed = errors.New("failed to decode image")
-	ErrBufTooSmall    = errors.New("buffer too small to hold image")
+	ErrInvalidImage     = errors.New("unrecognized image format")
+	ErrDecodingFailed   = errors.New("failed to decode image")
+	ErrBufTooSmall      = errors.New("buffer too small to hold image")
+	ErrBufEmpty         = errors.New("buffer is empty")
+	ErrFrameBufNoPixels = errors.New("Framebuffer contains no pixels")
 
 	gif87Magic = []byte("GIF87a")
 	gif89Magic = []byte("GIF89a")
@@ -61,7 +63,7 @@ func isGIF(maybeGIF []byte) bool {
 func NewDecoder(buf []byte) (Decoder, error) {
 	// Check buffer length before accessing it
 	if len(buf) == 0 {
-		return nil, errors.New("Image buffer is empty")
+		return nil, ErrBufEmpty
 	}
 
 	isBufGIF := isGIF(buf)

--- a/lilliput.go
+++ b/lilliput.go
@@ -13,7 +13,6 @@ var (
 	ErrInvalidImage     = errors.New("unrecognized image format")
 	ErrDecodingFailed   = errors.New("failed to decode image")
 	ErrBufTooSmall      = errors.New("buffer too small to hold image")
-	ErrBufEmpty         = errors.New("buffer is empty")
 	ErrFrameBufNoPixels = errors.New("Framebuffer contains no pixels")
 
 	gif87Magic = []byte("GIF87a")
@@ -63,7 +62,7 @@ func isGIF(maybeGIF []byte) bool {
 func NewDecoder(buf []byte) (Decoder, error) {
 	// Check buffer length before accessing it
 	if len(buf) == 0 {
-		return nil, ErrBufEmpty
+		return nil, ErrBufTooSmall
 	}
 
 	isBufGIF := isGIF(buf)

--- a/opencv.go
+++ b/opencv.go
@@ -231,6 +231,11 @@ func (f *Framebuffer) PixelType() PixelType {
 }
 
 func newOpenCVDecoder(buf []byte) (*openCVDecoder, error) {
+	// Check buffer length before accessing it
+	if len(buf) == 0 {
+		return nil, errors.New("Image buffer is empty")
+	}
+
 	mat := C.opencv_mat_create_from_data(C.int(len(buf)), 1, C.CV_8U, unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
 
 	// this next check is sort of silly since this array is 1-dimensional

--- a/opencv.go
+++ b/opencv.go
@@ -13,7 +13,6 @@ package lilliput
 import "C"
 
 import (
-	"errors"
 	"io"
 	"time"
 	"unsafe"
@@ -173,7 +172,7 @@ func (f *Framebuffer) ResizeTo(width, height int, dst *Framebuffer) error {
 // not large enough to hold the given dimensions.
 func (f *Framebuffer) Fit(width, height int, dst *Framebuffer) error {
 	if f.mat == nil {
-		return errors.New("Framebuffer contains no pixels")
+		return ErrFrameBufNoPixels
 	}
 
 	aspectIn := float64(f.width) / float64(f.height)

--- a/opencv.go
+++ b/opencv.go
@@ -231,11 +231,6 @@ func (f *Framebuffer) PixelType() PixelType {
 }
 
 func newOpenCVDecoder(buf []byte) (*openCVDecoder, error) {
-	// Check buffer length before accessing it
-	if len(buf) == 0 {
-		return nil, errors.New("Image buffer is empty")
-	}
-
 	mat := C.opencv_mat_create_from_data(C.int(len(buf)), 1, C.CV_8U, unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
 
 	// this next check is sort of silly since this array is 1-dimensional


### PR DESCRIPTION
The current code produces the following error on an empty buffer. The added range check prevents it from panicking, instead returning an error.

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/discordapp/lilliput.newOpenCVDecoder(0xc4200e6200, 0x0, 0x200, 0x0, 0x0, 0xc420130040)
        /home/alexrsagen/go/src/github.com/discordapp/lilliput/opencv.go:234 +0x16a
github.com/discordapp/lilliput.NewDecoder(0xc4200e6200, 0x0, 0x200, 0x0, 0x200, 0x0, 0x0)
        /home/alexrsagen/go/src/github.com/discordapp/lilliput/lilliput.go:67 +0x72
```