### PR TITLE
on partial frame, allocate a transparency color

### DIFF
--- a/giflib.cpp
+++ b/giflib.cpp
@@ -177,7 +177,6 @@ static bool giflib_set_frame_gcb(GifFileType *gif, const GraphicsControlBlock *g
     for (int i = 0; i < gif->ExtensionBlockCount; i++) {
         ExtensionBlock *b = &gif->ExtensionBlocks[i];
         if (b->Function == GRAPHICS_EXT_FUNC_CODE) {
-            printf("setting gcb on block %d\n", i);
             int res = EGifGCBToExtension(gcb, b->Bytes);
             return res == GIF_OK;
         }

--- a/giflib.cpp
+++ b/giflib.cpp
@@ -399,6 +399,11 @@ static bool giflib_decoder_render_frame(giflib_decoder d, GraphicsControlBlock *
         pixel_index += skip_right;
     }
 
+    // because we turn partial frames into full frames, we need to ensure that a transparency color
+    // is defined, so that the encoder can use it (we convert partial frames to full frames with
+    // a lot of transparency)
+
+    // let's check if we have a partial frame and whether no transparency is defined
     bool have_partial_frame = false;
     have_partial_frame |= frame_height < buf_height;
     have_partial_frame |= frame_width < buf_width;


### PR DESCRIPTION
The GIF spec is fun and allows the GIF itself to define a canvas/viewport size, and then each frame can define its own size. Frames can also define a starting coordinate, so for example a 400x400 gif might have a 30x20 frame that starts at (180, 100).

I took a lazy approach to these partial frames. Rather than trying to figure out how to rescale the coordinates, e.g. what is 99% of (180, 100), I decided to just composite the new frame on top of the previous frame and then use standard resizing for the composited frame. In the encoder, we consider which color from the palette to use. The right color could be a transparency color if the color at (x, y) is close to the color at (x, y) in the previous frame. And so my intention was that we would turn these partial frames into full frames with a bunch of transparency everywhere.

This almost worked except that sometimes frames don't have a transparency color. There's an extension block in the gif format that tells you which color is transparency, it's essentially just an override that tells you "if you see this color palette index, it /actually/ means transparency, ignore whatever color is there". This PR forces the gif to have a transparency color in the last index of the relevant color palette. We're essentially discarding one color. I chose the last index because I'm assuming the original gif encoder put the most common colors first, though I haven't validated that assumption. At the least, this will lose some color info, but the weird partial frame glitches will be gone.