### PR TITLE
Add PictureInPicture function

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ pass the `orientation` value given by the image's `ImageHeader`, then the
 resulting image has its orientation normalized to the
 default orientation.
 
+
+```go
+func (f *lilliput.Framebuffer) PictureInPicture(src *Framebuffer, x, y int)
+```
+Allows you to place `src` into the frame buffer which you are calling this from.
+You can use `x` and `y` to set the co-ordinates where `src` will be placed.
+
 ```go
 func (f *lilliput.Framebuffer) ResizeTo(width, height int, dst *lilliput.Framebuffer) error
 ```

--- a/opencv.cpp
+++ b/opencv.cpp
@@ -147,6 +147,13 @@ void opencv_mat_resize(const opencv_mat src, opencv_mat dst, int width, int heig
     cv::resize(*static_cast<const cv::Mat *>(src), *static_cast<cv::Mat *>(dst), cv::Size(width, height), 0, 0, interpolation);
 }
 
+void opencv_mat_picture_in_picture(const opencv_mat src, opencv_mat dst, int x, int y) {
+    auto dstMat = *static_cast<cv::Mat *>(dst);
+    auto srcMatPtr = static_cast<cv::Mat *>(src);
+    cv::Mat Region = dstMat(CvRect(x, y, srcMatPtr->cols, srcMatPtr->rows));
+    srcMatPtr->copyTo(Region);
+}
+
 opencv_mat opencv_mat_crop(const opencv_mat src, int x, int y, int width, int height) {
     auto ret = new cv::Mat;
     *ret = (*static_cast<const cv::Mat *>(src))(cv::Rect(x, y, width, height));

--- a/opencv.go
+++ b/opencv.go
@@ -192,6 +192,20 @@ func (f *Framebuffer) ResizeTo(width, height int, dst *Framebuffer) error {
 	return nil
 }
 
+// PictureInPicture allows you to take the src and place it inside this buffer (the destination).
+// The x/y arguments allow you to set the co-ordinates where this will be placed.
+func (f *Framebuffer) PictureInPicture(src *Framebuffer, x, y int) {
+	if x < 1 {
+		x = 1
+	}
+
+	if y < 1 {
+		y = 1
+	}
+
+	C.opencv_mat_picture_in_picture(src.mat, f.mat, C.int(x), C.int(y))
+}
+
 // Fit performs a resizing and cropping transform on the Framebuffer and puts the result
 // in the provided destination Framebuffer. This function does preserve aspect ratio
 // but will crop columns or rows from the edges of the image as necessary in order to

--- a/opencv.hpp
+++ b/opencv.hpp
@@ -55,6 +55,7 @@ void opencv_mat_orientation_transform(CVImageOrientation orientation, opencv_mat
 int opencv_mat_get_width(const opencv_mat mat);
 int opencv_mat_get_height(const opencv_mat mat);
 void *opencv_mat_get_data(const opencv_mat mat);
+void opencv_mat_picture_in_picture(const opencv_mat src, opencv_mat dst, int x, int y);
 
 opencv_encoder opencv_encoder_create(const char *ext, opencv_mat dst);
 void opencv_encoder_release(opencv_encoder e);


### PR DESCRIPTION
Allows you to place `src` into the frame buffer which you are calling this from.
You can use `x` and `y` to set the co-ordinates where `src` will be placed.
